### PR TITLE
Feat/2 securities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/partners/total/PartnersApplication.java
+++ b/src/main/java/com/partners/total/PartnersApplication.java
@@ -2,8 +2,10 @@ package com.partners.total;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class PartnersApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/partners/total/mydata/domain/StocksRepository.java
+++ b/src/main/java/com/partners/total/mydata/domain/StocksRepository.java
@@ -1,9 +1,23 @@
 package com.partners.total.mydata.domain;
 
+import com.partners.total.securities.dto.StocksDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface StocksRepository extends JpaRepository<Stocks, Integer> {
     List<Stocks> findByAccount(Account account);
+
+    Optional<Stocks> findStocksByAccountIdAndStockCode(int accountId, String stockCode);
+
+    @Modifying
+    @Query("UPDATE Stocks s SET s.quantity = :quantity WHERE s.id = :id")
+    Optional<Integer> updateQuantityByAccountIdAndQuantity(@Param("id") Integer id, @Param("quantity") Integer quantity);
+
+//    @Query("SELECT Stocks FROM Stocks WHERE account.id = :accountId")
+    List<Stocks> findStocksByAccountId(int accountId);
 }

--- a/src/main/java/com/partners/total/mydata/domain/StocksRepository.java
+++ b/src/main/java/com/partners/total/mydata/domain/StocksRepository.java
@@ -1,6 +1,5 @@
 package com.partners.total.mydata.domain;
 
-import com.partners.total.securities.dto.StocksDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/partners/total/securities/config/WebClientConfig.java
+++ b/src/main/java/com/partners/total/securities/config/WebClientConfig.java
@@ -1,0 +1,39 @@
+package com.partners.total.securities.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Value("${app.key}")
+    private String appkey;
+
+    @Value("${app.secret}")
+    private String appsecret;
+
+    private final WebClient.Builder webClientBuilder;
+
+    public WebClientConfig(WebClient.Builder webClientBuilder) {
+        this.webClientBuilder = webClientBuilder;
+    }
+
+    @Bean
+    public WebClient webClient() {
+        return webClientBuilder
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .baseUrl("https://openapi.koreainvestment.com:9443")
+                .build();
+    }
+
+    public String getAppkey() {
+        return appkey;
+    }
+
+    public String getAppsecret() {
+        return appsecret;
+    }
+}

--- a/src/main/java/com/partners/total/securities/dto/ClosePriceDTO.java
+++ b/src/main/java/com/partners/total/securities/dto/ClosePriceDTO.java
@@ -1,0 +1,36 @@
+package com.partners.total.securities.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ClosePriceDTO {
+    private String rt_cd;
+    private String msg_cd;
+    private String msg1;
+    private ClosePriceDTO.Output1 output1;
+
+    public ClosePriceDTO() {}
+
+    public ClosePriceDTO(String rt_cd, String msg_cd, String msg1, ClosePriceDTO.Output1 output1) {
+        this.rt_cd = rt_cd;
+        this.msg_cd = msg_cd;
+        this.msg1 = msg1;
+        this.output1 = output1;
+    }
+
+    @Getter
+    @Setter
+    public static class Output1 {
+        private String stck_prdy_clpr;
+        private String hts_kor_isnm;
+
+        public Output1() {}
+
+        public Output1(String stck_prdy_clpr, String hts_kor_isnm) {
+            this.stck_prdy_clpr = stck_prdy_clpr;
+            this.hts_kor_isnm = hts_kor_isnm;
+        }
+    }
+}

--- a/src/main/java/com/partners/total/securities/dto/CurrentPriceDTO.java
+++ b/src/main/java/com/partners/total/securities/dto/CurrentPriceDTO.java
@@ -1,0 +1,35 @@
+package com.partners.total.securities.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CurrentPriceDTO {
+
+    private String rt_cd;
+    private String msg_cd;
+    private String msg1;
+    private CurrentPriceDTO.Output output;
+
+    public CurrentPriceDTO() {}
+
+    public CurrentPriceDTO(String rt_cd, String msg_cd, String msg1, CurrentPriceDTO.Output output) {
+        this.rt_cd = rt_cd;
+        this.msg_cd = msg_cd;
+        this.msg1 = msg1;
+        this.output = output;
+    }
+
+    @Getter
+    @Setter
+    public static class Output {
+        private String stck_prpr;
+
+        public Output() {}
+
+        public Output(String stck_prpr) {
+            this.stck_prpr = stck_prpr;
+        }
+    }
+}

--- a/src/main/java/com/partners/total/securities/dto/StockCodesDTO.java
+++ b/src/main/java/com/partners/total/securities/dto/StockCodesDTO.java
@@ -1,0 +1,11 @@
+package com.partners.total.securities.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class StockCodesDTO {
+
+    private List<String> stockCodes;
+}

--- a/src/main/java/com/partners/total/securities/dto/StockPriorityDTO.java
+++ b/src/main/java/com/partners/total/securities/dto/StockPriorityDTO.java
@@ -1,0 +1,13 @@
+package com.partners.total.securities.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StockPriorityDTO {
+
+    private int accountId;
+    private int quantity;
+    private String stockCode;
+}

--- a/src/main/java/com/partners/total/securities/dto/StocksDTO.java
+++ b/src/main/java/com/partners/total/securities/dto/StocksDTO.java
@@ -1,0 +1,16 @@
+package com.partners.total.securities.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StocksDTO {
+
+    private int id;
+    private int quantity;
+    private int accountId;
+    private String stockCode;
+    private int userId;
+    private String companyCode;
+}

--- a/src/main/java/com/partners/total/securities/service/SecuritiesService.java
+++ b/src/main/java/com/partners/total/securities/service/SecuritiesService.java
@@ -1,0 +1,108 @@
+package com.partners.total.securities.service;
+
+import com.partners.total.mydata.domain.*;
+import com.partners.total.securities.dto.*;
+import com.partners.total.securities.utils.StockData;
+import com.partners.total.securities.utils.StockOAuth;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class SecuritiesService {
+
+    private final StockOAuth stockOAuthService;
+    private final StockData stockData;
+    private final UserRepository userRepository;
+    private final AccountRepository accountRepository;
+    private final StocksRepository stocksRepository;
+
+    private String accessToken = null;
+
+//    public ClosePriceDTO getPreviousClosePrice(String code) {
+//
+//        checkoutToken();
+//
+//        return stockData.fetchClosePriceData(code, accessToken);
+//    }
+
+    private CurrentPriceDTO getCurrentPrice(String code) {
+
+        checkoutToken();
+
+        return stockData.fetchCurrentPriceData(code, accessToken);
+    }
+
+    @Transactional
+    public Map<String, ?> requestSellStocks(StockPriorityDTO stockPriorityDTO) {
+
+        Stocks stocks = stocksRepository
+                .findStocksByAccountIdAndStockCode(
+                        stockPriorityDTO.getAccountId(),
+                        stockPriorityDTO.getStockCode()
+                )
+                .orElseThrow(NoSuchElementException::new);
+
+        if (stocks.getQuantity() - stockPriorityDTO.getQuantity() < 0) {
+
+            return null;
+        }
+
+        System.out.println("stocks.getQuantity() = " + stocks.getQuantity());
+
+        int currentPriceOfStock = Integer.parseInt(getCurrentPrice(stockPriorityDTO.getStockCode()).getOutput().getStck_prpr());
+
+        int sellAmount = stockPriorityDTO.getQuantity() * currentPriceOfStock;
+
+        int restQuantity = stocks.getQuantity() - stockPriorityDTO.getQuantity();
+
+        System.out.println("restQuantity = " + restQuantity);
+
+        stocksRepository
+                .updateQuantityByAccountIdAndQuantity(stocks.getId(), restQuantity)
+                .orElseThrow(() -> new NoSuchElementException("그런 스톡 없어용"));
+
+        Map<String, Integer> map = new HashMap<>();
+        map.put("sellAmount", sellAmount);
+        return map;
+    }
+
+    public Map<String, String> getPreviousClosePriceList(StockCodesDTO stockCodesDTO) {
+
+        checkoutToken();
+
+        Map<String, String> previousClosePriceList = new HashMap<>();
+
+        for (String stockCode : stockCodesDTO.getStockCodes()) {
+
+            ClosePriceDTO closePriceDTO = stockData.fetchClosePriceData(stockCode, accessToken);
+
+            previousClosePriceList.put(stockCode, closePriceDTO.getOutput1().getStck_prdy_clpr());
+        }
+
+        return previousClosePriceList;
+    }
+
+    @Scheduled(cron = "0 0 0 * * *") // 자정
+    protected void getOAuthToken() {
+        accessToken = stockOAuthService.getAccessToken(accessToken);
+    }
+
+    private void checkoutToken() {
+        if (accessToken == null) {
+            getOAuthToken();
+        }
+    }
+
+    public List<Stocks> getAllStocksByAccountId(int accountId) {
+
+        return stocksRepository.findStocksByAccountId(accountId);
+    }
+}

--- a/src/main/java/com/partners/total/securities/service/SecuritiesService.java
+++ b/src/main/java/com/partners/total/securities/service/SecuritiesService.java
@@ -26,13 +26,6 @@ public class SecuritiesService {
 
     private String accessToken = null;
 
-//    public ClosePriceDTO getPreviousClosePrice(String code) {
-//
-//        checkoutToken();
-//
-//        return stockData.fetchClosePriceData(code, accessToken);
-//    }
-
     private CurrentPriceDTO getCurrentPrice(String code) {
 
         checkoutToken();

--- a/src/main/java/com/partners/total/securities/utils/StockData.java
+++ b/src/main/java/com/partners/total/securities/utils/StockData.java
@@ -1,0 +1,111 @@
+package com.partners.total.securities.utils;
+
+import com.partners.total.securities.dto.ClosePriceDTO;
+import com.partners.total.securities.dto.CurrentPriceDTO;
+import com.partners.total.securities.config.WebClientConfig;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+
+@Service
+public class StockData {
+
+    private final WebClient webClient;
+    private final String appkey;
+    private final String appsecret;
+
+    public StockData(WebClientConfig webClientConfig) {
+        this.webClient = webClientConfig.webClient();
+        this.appkey = webClientConfig.getAppkey();
+        this.appsecret = webClientConfig.getAppsecret();
+    }
+
+    public synchronized ClosePriceDTO fetchClosePriceData(String code, String accessToken) {
+
+        ClosePriceDTO response = null;
+
+        try {
+            response = webClient.get()
+                    .uri(uriBuilder ->
+                        uriBuilder
+                                .path("/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice")
+                                .queryParam("FID_COND_MRKT_DIV_CODE", "J")
+                                .queryParam("FID_INPUT_ISCD", code)
+                                .queryParam("FID_INPUT_DATE_1", getYesterdayDateString())
+                                .queryParam("FID_INPUT_DATE_2", getTodayDateString())
+                                .queryParam("FID_PERIOD_DIV_CODE", "D")
+                                .queryParam("FID_ORG_ADJ_PRC", "1")
+                                .build()
+                    )
+                    .headers(headers -> {
+                        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+                        headers.set("appkey", appkey);
+                        headers.set("appsecret", appsecret);
+                        headers.set("tr_id", "FHKST03010100");
+                    })
+                    .retrieve()
+                    .bodyToMono(ClosePriceDTO.class)
+                    .onErrorResume(e -> {
+                        System.err.println("전일 종가 가져오기 에러 = " + e.getMessage());
+                        return Mono.empty();
+                    })
+                    .block();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return response;
+    }
+
+    private static String getYesterdayDateString(){
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+        return yesterday.format(formatter);
+    }
+
+    private static String getTodayDateString() {
+        LocalDate today = LocalDate.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+        return today.format(formatter);
+    }
+
+    public synchronized CurrentPriceDTO fetchCurrentPriceData(String code, String accessToken) {
+
+        CurrentPriceDTO response = null;
+
+        try {
+            response = webClient.get()
+                    .uri(uriBuilder ->
+                            uriBuilder
+                                    .path("/uapi/domestic-stock/v1/quotations/inquire-price")
+                                    .queryParam("FID_COND_MRKT_DIV_CODE", "J")
+                                    .queryParam("FID_INPUT_ISCD", code)
+                                    .build()
+                    )
+                    .headers(headers -> {
+                        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+                        headers.set("appkey", appkey);
+                        headers.set("appsecret", appsecret);
+                        headers.set("tr_id", "FHKST01010100");
+                    })
+                    .retrieve()
+                    .bodyToMono(CurrentPriceDTO.class)
+                    .onErrorResume(e -> {
+                        System.err.println("현재가 가져오기 에러 = " + e.getMessage());
+                        return Mono.empty();
+                    })
+                    .block();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/com/partners/total/securities/utils/StockOAuth.java
+++ b/src/main/java/com/partners/total/securities/utils/StockOAuth.java
@@ -1,0 +1,92 @@
+package com.partners.total.securities.utils;
+
+import com.partners.total.securities.config.WebClientConfig;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+public class StockOAuth {
+
+    private final WebClient webClient;
+    private final String appkey;
+    private final String appsecret;
+
+    public StockOAuth(WebClientConfig webClientConfig) {
+        this.webClient = webClientConfig.webClient();
+        this.appkey = webClientConfig.getAppkey();
+        this.appsecret = webClientConfig.getAppsecret();
+    }
+
+    public synchronized String fetchOAuthToken() {
+
+        String accessToken;
+
+        try {
+            OAuthResponse response = webClient.post()
+                    .uri("/oauth2/tokenP")
+                    .bodyValue(new OAuthRequestBody("client_credentials", appkey, appsecret))
+                    .retrieve()
+                    .onStatus(
+                            status -> status.is4xxClientError() || status.is5xxServerError(),
+                            clientResponse -> clientResponse.bodyToMono(String.class)
+                                    .flatMap(errorBody -> {
+                                        String errorMessage = String.format("Error: %s, Status Code: %d",
+                                                errorBody, clientResponse.statusCode().value());
+                                        return Mono.error(new RuntimeException(errorMessage));
+                                    })
+                    )
+                    .bodyToMono(OAuthResponse.class)
+                    .block();
+
+            accessToken = response.getAccessToken(); // 토큰을 전역 변수에 저장
+
+            System.out.println("accessToken = " + accessToken);
+        } catch (Exception e) {
+            e.printStackTrace();
+            accessToken = null;
+        }
+
+        return accessToken;
+    }
+
+    public synchronized String getAccessToken(String accessToken) {
+        return accessToken != null ? accessToken : fetchOAuthToken(); // 토큰이 없으면 가져옴
+    }
+
+    // 내부 클래스들 정의
+    @Getter
+    private static class OAuthRequestBody {
+        private final String grant_type;
+        private final String appkey;
+        private final String appsecret;
+
+        public OAuthRequestBody(String grant_type, String appkey, String appsecret) {
+            this.grant_type = grant_type;
+            this.appkey = appkey;
+            this.appsecret = appsecret;
+        }
+    }
+
+    @Setter
+    public static class OAuthResponse {
+        private String access_token;
+        private String access_token_token_expired;
+        private String token_type;
+        private int expires_in;
+
+        public String getAccessToken() {
+            return access_token;
+        }
+
+        public String getTokenType() {
+            return token_type;
+        }
+
+        public int getExpiresIn() {
+            return expires_in;
+        }
+    }
+}

--- a/src/main/java/com/partners/total/securities/web/SecuritiesController.java
+++ b/src/main/java/com/partners/total/securities/web/SecuritiesController.java
@@ -1,10 +1,8 @@
 package com.partners.total.securities.web;
 
 import com.partners.total.mydata.domain.Stocks;
-import com.partners.total.securities.dto.CurrentPriceDTO;
 import com.partners.total.securities.dto.StockCodesDTO;
 import com.partners.total.securities.dto.StockPriorityDTO;
-import com.partners.total.securities.dto.StocksDTO;
 import com.partners.total.securities.service.SecuritiesService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/partners/total/securities/web/SecuritiesController.java
+++ b/src/main/java/com/partners/total/securities/web/SecuritiesController.java
@@ -1,0 +1,49 @@
+package com.partners.total.securities.web;
+
+import com.partners.total.mydata.domain.Stocks;
+import com.partners.total.securities.dto.CurrentPriceDTO;
+import com.partners.total.securities.dto.StockCodesDTO;
+import com.partners.total.securities.dto.StockPriorityDTO;
+import com.partners.total.securities.dto.StocksDTO;
+import com.partners.total.securities.service.SecuritiesService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/securities")
+public class SecuritiesController {
+
+    private final SecuritiesService securitiesService;
+
+    @GetMapping("/accounts/stock/{accountId}")
+    public ResponseEntity<?> getAllAccounts(@PathVariable int accountId) {
+
+        List<Stocks> stocks = securitiesService.getAllStocksByAccountId(accountId);
+
+        return new ResponseEntity<>(stocks, HttpStatus.OK);
+    }
+
+    // 증권 매도 요청
+    @PutMapping("/stocks")
+    public ResponseEntity<?> requestSellStocks(@RequestBody StockPriorityDTO stockPriorityDTO) {
+
+        Map<String, ?> amount = securitiesService.requestSellStocks(stockPriorityDTO);
+
+        return new ResponseEntity<>(amount, HttpStatus.OK);
+    }
+
+    // 증권 전일 종가 요청
+    @GetMapping("/stocks")
+    public ResponseEntity<?> getPreviousClosePrice(@RequestBody StockCodesDTO stockCodesDTO) {
+
+        Map<String, String> previousClosePriceList = securitiesService.getPreviousClosePriceList(stockCodesDTO);
+
+        return new ResponseEntity<>(previousClosePriceList, HttpStatus.OK);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,10 @@
 spring.application.name=partners
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.datasource.url=jdbc:mysql://${DATASOURCE_ENDPOINT}:${DATASOURCE_PORT}/${DATASOURCE_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.datasource.username=${DATASOURCE_USERNAME}
 spring.datasource.password=${DATASOURCE_PASSWORD}
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+
+app.key=${APP_KEY}
+app.secret=${APP_SECRET}


### PR DESCRIPTION
## 🔖 PR 타입
- [x] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🌿 반영 브랜치
ex) feat/2-securities-> main

## ⚒️ 구현 사항
더미데이터 서버 증권사 api 로직을 구현함

## ✅ 테스트 결과

계좌에 따른 모든 증권 조회 api
![image](https://github.com/user-attachments/assets/685c06f1-abc7-4b28-80d0-b09ef2e9d47b)
불필요한 데이터 발생으로 추가 및 개선이 필요한 상태

증권 전일 종가 요청 api
![image](https://github.com/user-attachments/assets/5b4ca5f8-eef0-419d-93dd-82932b64d5be)
우선 GET인데 RequestBody로 데이터를 받는 것이 불편함

증권 매도 요청 api
![image](https://github.com/user-attachments/assets/4c447d4d-4168-439a-ae8c-c83db775470f)
증권 수량이 줄어들고, 현재가로 계산된 금액을 반환
